### PR TITLE
Fix release workflow to skip publish confirmation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
           set -euo pipefail
           npm whoami || { echo "npm auth failed"; exit 1; }
           # Single pipeline step (your script):
-          npm run release -- --yes
+          npm run release

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "scripts": {
     "lint": "wireit",
-    "release": "lerna publish --no-private --no-changelog --message \"chore(release): publish releases\" --signoff-git-commit --sign-git-commit --sign-git-tag && node ./scripts/update-citation.ts --version-source date",
-    "release:force": "lerna publish --no-private --no-changelog --force-publish --message \"chore(release): publish %s\" --signoff-git-commit --sign-git-commit --sign-git-tag",
+    "release": "lerna publish --no-private --no-changelog --message \"chore(release): publish releases\" --signoff-git-commit --sign-git-commit --sign-git-tag --yes && node ./scripts/update-citation.ts --version-source date",
+    "release:force": "lerna publish --no-private --no-changelog --force-publish --message \"chore(release): publish %s\" --signoff-git-commit --sign-git-commit --sign-git-tag --yes",
     "update": "wireit",
 
     "ci:version": "lerna version --yes",


### PR DESCRIPTION
## Summary
- add --yes to the release scripts so lerna publishes non-interactively
- stop passing --yes via the workflow step now that the script handles it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907ccdcb6ec83299933865c18fdf9b3