### PR TITLE
chore(ci): ensure release workflow adds DCO sign-off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure git author and DCO sign-off
+        run: |
+          set -euo pipefail
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global format.signoff true
+
       # Optional: simple actor allow-list (you can expand the list)
       - name: Ensure current actor is allowed
         if: ${{ !contains('["davidsneighbour"]', github.actor) }}


### PR DESCRIPTION
## Summary
- configure the release workflow to set the git author from the running actor
- enable automatic Signed-off-by lines so release commits satisfy the DCO check

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907d25dfc4c8329b76a333d6bdc167a