### PR TITLE
Fix release workflow to avoid GPG signing requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global format.signoff true
 
+      - name: Disable GPG signing in CI
+        run: |
+          set -euo pipefail
+          git config --global commit.gpgsign false
+          git config --global tag.gpgsign false
+
       # Optional: simple actor allow-list (you can expand the list)
       - name: Ensure current actor is allowed
         if: ${{ !contains('["davidsneighbour"]', github.actor) }}
@@ -67,5 +73,4 @@ jobs:
         run: |
           set -euo pipefail
           npm whoami || { echo "npm auth failed"; exit 1; }
-          # Single pipeline step (your script):
           npm run release

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "scripts": {
     "lint": "wireit",
-    "release": "lerna publish --no-private --no-changelog --message \"chore(release): publish releases\" --signoff-git-commit --sign-git-commit --sign-git-tag --yes && node ./scripts/update-citation.ts --version-source date",
-    "release:force": "lerna publish --no-private --no-changelog --force-publish --message \"chore(release): publish %s\" --signoff-git-commit --sign-git-commit --sign-git-tag --yes",
+    "release": "node ./scripts/update-citation.ts --version-source date --no-commit && git add CITATION.cff && lerna publish --no-private --no-changelog --message \"chore(release): publish %s\" --signoff-git-commit --yes",
+    "release:force": "node ./scripts/update-citation.ts --version-source date --no-commit && git add CITATION.cff && lerna publish --no-private --no-changelog --force-publish --message \"chore(release): publish %s\" --signoff-git-commit --yes",
     "update": "wireit",
 
     "ci:version": "lerna version --yes",


### PR DESCRIPTION
## Summary
- disable git commit and tag signing inside the release workflow so CI no longer needs a GPG key
- update the lerna release scripts to stage the citation change before publishing and drop the signing flags for compatibility with release tokens

## Testing
- npm run lint *(fails: lockfile-lint rejects git+ssh dependency for remark-lint-frontmatter-schema)*

------
https://chatgpt.com/codex/tasks/task_e_6907d4847c888329a97de005cc4ed975